### PR TITLE
Rename display name to OpenDentist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<img src="readme-banner.png" alt="Open Dentist preview" width="100%" />
+<img src="readme-banner.png" alt="OpenDentist preview" width="100%" />
 
-# Open Dentist
+# OpenDentist
 
 [![Deploy with Clawnify](https://app.clawnify.com/deploy-button.svg)](https://app.clawnify.com/deploy?repo=clawnify/open-dentist)
 

--- a/clawnify.json
+++ b/clawnify.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://app.clawnify.com/schema/v1/clawnify.json",
   "version": 1,
-  "name": "Open Dentist",
+  "name": "OpenDentist",
   "description": "Open-source dental practice management software — an alternative to CareStack and Archy. Multi-room agenda scheduling, patient records with tooth charting, treatment planning, clinical notes, and billing. Built for solo practices, group practices, and DSOs.",
   "icon": "icon.svg",
   "tags": ["dental", "healthcare", "practice-management", "scheduling", "patients"],

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Open Dentist</title>
+  <title>OpenDentist</title>
   <meta name="description" content="Open-source dental practice management — scheduling, patient charts, treatment planning, clinical notes, and billing.">
   <link rel="icon" type="image/svg+xml" href="/icon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Open Dentist",
+  "name": "OpenDentist",
   "description": "Open-source dental practice management — multi-room agenda scheduling, patient records with tooth charting, treatment planning, clinical notes, and billing. An alternative to CareStack and Archy for solo practices, group practices, and DSOs.",
   "framework": "react+hono",
   "files": [

--- a/src/client/components/sidebar.tsx
+++ b/src/client/components/sidebar.tsx
@@ -48,7 +48,7 @@ export function Sidebar({
         <div className="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground">
           <Stethoscope className="h-4 w-4" />
         </div>
-        <span className="text-base font-semibold tracking-tight">Open Dentist</span>
+        <span className="text-base font-semibold tracking-tight">OpenDentist</span>
       </div>
 
       <nav className="flex-1 overflow-y-auto px-2 py-3">

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,7 +6,7 @@ import { query, get, run } from "./db";
 type Env = { Bindings: { DB: D1Database } };
 
 const app = createApp<Env>({
-  title: "Open Dentist",
+  title: "OpenDentist",
   version: "1.0.0",
   description: "Dental practice management: patients, appointments, operatories, treatments, and billing.",
 });


### PR DESCRIPTION
Collapses the spaced product name into the single-word `OpenX` form, matching the OpenCut convention.

Touches display surfaces only: README, `clawnify.json` name, agent guide, app/API titles, `manifest.json`, and UI strings.

Unchanged: repo slug, package name, app slug, D1 database names.