### PR TITLE
Point repo links at the renamed repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # OpenDentist
 
-[![Deploy with Clawnify](https://app.clawnify.com/deploy-button.svg)](https://app.clawnify.com/deploy?repo=clawnify/open-dentist)
+[![Deploy with Clawnify](https://app.clawnify.com/deploy-button.svg)](https://app.clawnify.com/deploy?repo=clawnify/OpenDentist)
 
 Open-source dental practice management — an alternative to CareStack and Archy for solo practices, group practices, and DSOs.
 


### PR DESCRIPTION
Follow-up to the display-name rename: the GitHub repository was renamed to its `OpenX` name, so the deploy badge, clone URL and raw asset links now use it.

npm package name and app slug are unchanged. The old repository path still redirects, so nothing was broken in the meantime.