### PR TITLE
Seed settings and sample data from the app, not schema.sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pnpm typecheck
 pnpm build
 ```
 
-The dev script applies `src/server/schema.sql` to the local D1 database, then runs Vite and Wrangler in parallel. The schema seeds 3 operatories, 3 practitioners, and 6 treatment types so the agenda is usable on first boot.
+The dev script applies `src/server/schema.sql` to the local D1 database, then runs Vite and Wrangler in parallel. On its first request the app seeds 3 operatories, 3 practitioners, and 6 treatment types so the agenda is usable on first boot.
 
 ## Deploy
 
@@ -69,7 +69,8 @@ src/
   server/
     index.ts        Hono routes for every entity
     db.ts           D1 adapter (query / get / run)
-    schema.sql      Tables + seed data
+    schema.sql      Tables and indexes (DDL only)
+    seed.ts         First-run defaults + sample rows
   client/
     app.tsx         Shell + routing
     components/

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,12 @@ import { type Context } from "hono";
 import { z } from "zod";
 import { createApp } from "@clawnify/app";
 import { query, get, run } from "./db";
+import {
+  DEFAULT_SETTINGS,
+  SEED_OPERATORIES,
+  SEED_PRACTITIONERS,
+  SEED_TREATMENT_TYPES,
+} from "./seed";
 
 type Env = { Bindings: { DB: D1Database } };
 
@@ -9,6 +15,73 @@ const app = createApp<Env>({
   title: "OpenDentist",
   version: "1.0.0",
   description: "Dental practice management: patients, appointments, operatories, treatments, and billing.",
+});
+
+// ── First-run seed ─────────────────────────────────────────────────
+// `schema.sql` is applied as DDL only by the Clawnify deploy pipeline, so the
+// practice defaults and the sample rows are inserted here, on the first request
+// that reaches the app, instead of from the schema file.
+
+type SeedTable = "operatories" | "practitioners" | "treatment_types";
+
+let seeded = false;
+let seeding: Promise<void> | null = null;
+
+async function isEmpty(table: SeedTable): Promise<boolean> {
+  const row = await get<{ n: number }>(`SELECT COUNT(*) AS n FROM ${table}`);
+  return (row?.n ?? 0) === 0;
+}
+
+async function seedOnce(): Promise<void> {
+  for (const [key, value] of Object.entries(DEFAULT_SETTINGS)) {
+    await run("INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)", [key, value]);
+  }
+
+  // Sample rows land only while the table is still empty, so a redeploy never
+  // resurrects an operatory, practitioner or treatment type the user deleted.
+  if (await isEmpty("operatories")) {
+    for (const o of SEED_OPERATORIES) {
+      await run("INSERT INTO operatories (name, color, sort_order) VALUES (?, ?, ?)", [o.name, o.color, o.sort_order]);
+    }
+  }
+
+  if (await isEmpty("practitioners")) {
+    for (const p of SEED_PRACTITIONERS) {
+      await run("INSERT INTO practitioners (name, role, color) VALUES (?, ?, ?)", [p.name, p.role, p.color]);
+    }
+  }
+
+  if (await isEmpty("treatment_types")) {
+    for (const t of SEED_TREATMENT_TYPES) {
+      await run(
+        "INSERT INTO treatment_types (code, name, duration_minutes, default_fee, color) VALUES (?, ?, ?, ?, ?)",
+        [t.code, t.name, t.duration_minutes, t.default_fee, t.color],
+      );
+    }
+  }
+}
+
+async function ensureSeeded(): Promise<void> {
+  if (seeded) return;
+  try {
+    // Concurrent first requests share one run — the app shell fires four API
+    // calls in parallel on load, and without this each would read COUNT(*) = 0
+    // and insert its own copy of the sample rows.
+    // shortcut: the shared promise is per-isolate; if duplicates ever show up on
+    // a cold app, claim the seed atomically with an `INSERT OR IGNORE` marker row.
+    seeding ??= seedOnce();
+    await seeding;
+    seeded = true;
+  } catch {
+    // Sample data must never fail a request.
+    seeded = false;
+    seeding = null;
+  }
+}
+
+app.use("*", async (_c, next) => {
+  await ensureSeeded();
+  await next();
 });
 
 // ── Helpers ────────────────────────────────────────────────────────
@@ -972,7 +1045,7 @@ app.get("/api/settings", async (c) => {
   const rows = await query<{ key: string; value: string }>(
     "SELECT key, value FROM settings",
   ).catch(() => []);
-  const out: Record<string, string> = {};
+  const out: Record<string, string> = { ...DEFAULT_SETTINGS };
   for (const r of rows) out[r.key] = r.value;
   return c.json({ settings: out });
 });
@@ -991,7 +1064,7 @@ app.put("/api/settings", async (c) => {
     );
   }
   const rows = await query<{ key: string; value: string }>("SELECT key, value FROM settings");
-  const out: Record<string, string> = {};
+  const out: Record<string, string> = { ...DEFAULT_SETTINGS };
   for (const r of rows) out[r.key] = r.value;
   return c.json({ settings: out });
 });

--- a/src/server/schema.sql
+++ b/src/server/schema.sql
@@ -5,10 +5,9 @@ CREATE TABLE IF NOT EXISTS settings (
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
--- Defaults: day starts 07:00, ends 19:00. Stored as minutes from midnight.
-INSERT OR IGNORE INTO settings (key, value) VALUES ('day_start_minute', '420');
-INSERT OR IGNORE INTO settings (key, value) VALUES ('day_end_minute', '1140');
-INSERT OR IGNORE INTO settings (key, value) VALUES ('slot_minutes', '15');
+-- Defaults (day_start_minute 420, day_end_minute 1140, slot_minutes 15) are
+-- inserted by the app on first run — see `ensureSeeded` in src/server/index.ts.
+-- This file is applied as DDL only, so it must contain no INSERT statements.
 
 -- ── Operatories (treatment rooms / chairs) ──────────────────────
 CREATE TABLE IF NOT EXISTS operatories (
@@ -213,51 +212,8 @@ CREATE TABLE IF NOT EXISTS appointments_to_make (
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
--- ── Seed data (only inserted on first run) ─────────────────────
-INSERT INTO operatories (name, color, sort_order)
-SELECT 'Op 1', 'sky', 0
-WHERE NOT EXISTS (SELECT 1 FROM operatories);
-
-INSERT INTO operatories (name, color, sort_order)
-SELECT 'Op 2', 'emerald', 1
-WHERE (SELECT COUNT(*) FROM operatories) = 1;
-
-INSERT INTO operatories (name, color, sort_order)
-SELECT 'Op 3', 'amber', 2
-WHERE (SELECT COUNT(*) FROM operatories) = 2;
-
-INSERT INTO practitioners (name, role, color)
-SELECT 'Dr. Lee', 'dentist', 'teal'
-WHERE NOT EXISTS (SELECT 1 FROM practitioners);
-
-INSERT INTO practitioners (name, role, color)
-SELECT 'Dr. Patel', 'dentist', 'violet'
-WHERE (SELECT COUNT(*) FROM practitioners) = 1;
-
-INSERT INTO practitioners (name, role, color)
-SELECT 'Sarah Kim', 'hygienist', 'rose'
-WHERE (SELECT COUNT(*) FROM practitioners) = 2;
-
-INSERT INTO treatment_types (code, name, duration_minutes, default_fee, color)
-SELECT 'EXAM', 'Exam & Cleaning', 30, 120, 'sky'
-WHERE NOT EXISTS (SELECT 1 FROM treatment_types);
-
-INSERT INTO treatment_types (code, name, duration_minutes, default_fee, color)
-SELECT 'FILL', 'Restoration / Filling', 45, 220, 'amber'
-WHERE (SELECT COUNT(*) FROM treatment_types) = 1;
-
-INSERT INTO treatment_types (code, name, duration_minutes, default_fee, color)
-SELECT 'CROWN', 'Crown', 90, 1100, 'violet'
-WHERE (SELECT COUNT(*) FROM treatment_types) = 2;
-
-INSERT INTO treatment_types (code, name, duration_minutes, default_fee, color)
-SELECT 'ENDO', 'Root Canal', 90, 950, 'rose'
-WHERE (SELECT COUNT(*) FROM treatment_types) = 3;
-
-INSERT INTO treatment_types (code, name, duration_minutes, default_fee, color)
-SELECT 'EXT', 'Extraction', 30, 250, 'orange'
-WHERE (SELECT COUNT(*) FROM treatment_types) = 4;
-
-INSERT INTO treatment_types (code, name, duration_minutes, default_fee, color)
-SELECT 'CONS', 'Consultation', 20, 80, 'emerald'
-WHERE (SELECT COUNT(*) FROM treatment_types) = 5;
+-- ── Seed data ──────────────────────────────────────────────────
+-- The sample operatories, practitioners and treatment types moved into the app
+-- (src/server/seed.ts, applied by `ensureSeeded` in src/server/index.ts).
+-- A Clawnify deploy applies this file as DDL only: a single INSERT here fails
+-- the entire deploy, so no non-DDL statement may be added back.

--- a/src/server/seed.ts
+++ b/src/server/seed.ts
@@ -1,0 +1,61 @@
+/**
+ * First-run seed data.
+ *
+ * These rows used to live at the bottom of `schema.sql`. A Clawnify deploy
+ * applies that file as DDL only — a single INSERT fails the whole deploy — so
+ * they are inserted by the app instead, on the first request that reaches it.
+ * See `ensureSeeded` in `index.ts`.
+ */
+
+export interface SeedOperatory {
+  name: string;
+  color: string;
+  sort_order: number;
+}
+
+export interface SeedPractitioner {
+  name: string;
+  role: string;
+  color: string;
+}
+
+export interface SeedTreatmentType {
+  code: string;
+  name: string;
+  duration_minutes: number;
+  default_fee: number;
+  color: string;
+}
+
+/**
+ * Practice defaults: the day starts 07:00 and ends 19:00, in minutes from
+ * midnight. These three keys drive the agenda grid, so every read of
+ * `settings` falls back to them — the calendar renders correctly even on the
+ * very first request, before the seed has run.
+ */
+export const DEFAULT_SETTINGS: Record<string, string> = {
+  day_start_minute: "420",
+  day_end_minute: "1140",
+  slot_minutes: "15",
+};
+
+export const SEED_OPERATORIES: SeedOperatory[] = [
+  { name: "Op 1", color: "sky", sort_order: 0 },
+  { name: "Op 2", color: "emerald", sort_order: 1 },
+  { name: "Op 3", color: "amber", sort_order: 2 },
+];
+
+export const SEED_PRACTITIONERS: SeedPractitioner[] = [
+  { name: "Dr. Lee", role: "dentist", color: "teal" },
+  { name: "Dr. Patel", role: "dentist", color: "violet" },
+  { name: "Sarah Kim", role: "hygienist", color: "rose" },
+];
+
+export const SEED_TREATMENT_TYPES: SeedTreatmentType[] = [
+  { code: "EXAM", name: "Exam & Cleaning", duration_minutes: 30, default_fee: 120, color: "sky" },
+  { code: "FILL", name: "Restoration / Filling", duration_minutes: 45, default_fee: 220, color: "amber" },
+  { code: "CROWN", name: "Crown", duration_minutes: 90, default_fee: 1100, color: "violet" },
+  { code: "ENDO", name: "Root Canal", duration_minutes: 90, default_fee: 950, color: "rose" },
+  { code: "EXT", name: "Extraction", duration_minutes: 30, default_fee: 250, color: "orange" },
+  { code: "CONS", name: "Consultation", duration_minutes: 20, default_fee: 80, color: "emerald" },
+];


### PR DESCRIPTION
## The deploy failure this fixes

A Clawnify deploy applies `src/server/schema.sql` as **DDL only**. `parseSchemaObjects` throws — it does not skip — on any statement that is not `CREATE TABLE/INDEX/VIEW/TRIGGER` or `ALTER TABLE … ADD COLUMN`. A single seed row therefore failed the **entire** deploy, for every user including the public Deploy button:

```
SCHEMA: unsupported statement in schema.sql —
Offending statement: INSERT OR IGNORE INTO settings (key, value) VALUES ('day_start_minute', '420')
```

## What moved

Out of `schema.sql`, into the app:

- the three `settings` rows — `day_start_minute` `420`, `day_end_minute` `1140`, `slot_minutes` `15`
- the first-run demo rows — 3 operatories, 3 practitioners, 6 treatment types, previously written as `INSERT … SELECT … WHERE NOT EXISTS / COUNT(*)` guards

Values, ordering, colors, codes, durations and fees are unchanged. The rows now live in a new `src/server/seed.ts` as typed arrays, applied by `ensureSeeded()` in `src/server/index.ts`.

`ensureSeeded()` runs from a middleware registered immediately after `createApp()`, so it fires *after* `@clawnify/app`'s own `initDB(c.env)` middleware has bound the database and *before* any route handler. It is:

- **idempotent on settings** — `INSERT OR IGNORE`, so a user's edited value is never overwritten
- **empty-table-only for the demo rows** — a redeploy cannot resurrect an operatory, practitioner or treatment type the user deleted
- **never fatal** — the whole body is wrapped in `try/catch`; sample data must not fail a request
- **safe under concurrency** — the app shell fires four API calls in parallel on load, so concurrent first requests share one seeding run instead of each reading `COUNT(*) = 0` and inserting its own copy

## The settings defaults

The three settings keys are load-bearing, not decorative: `day_start_minute`, `day_end_minute` and `slot_minutes` drive the agenda grid's start, end and slot size, so a missing row is a broken calendar rather than absent sample data. Both `/api/settings` reads now fall back to the same defaults the seed writes, so the agenda renders correctly even on the very first request, before the seed has run. The client already carried matching defaults; the write path was already an upsert (`ON CONFLICT(key) DO UPDATE SET value = excluded.value`) and is unchanged.

## Verification

```
grep -nE "^\s*(INSERT|UPDATE|DELETE|DROP|PRAGMA|REPLACE)" src/server/schema.sql   # no matches
pnpm install --frozen-lockfile --ignore-scripts                                   # ok
tsc --noEmit -p .                                                                 # clean
vite build                                                                        # ✓ 1841 modules, built in 1.54s
```

Also run against a real local D1 through `wrangler dev`, not just typechecked:

- `wrangler d1 execute --file=src/server/schema.sql` applies cleanly (valid DDL-only)
- first request seeds exactly the old rows, with the old ids — `Op 1/Op 2/Op 3`, `Dr. Lee/Dr. Patel/Sarah Kim`, `EXAM`=1 … `CONS`=6, and `{"day_start_minute":"420","day_end_minute":"1140","slot_minutes":"15"}`
- repeated requests do not duplicate; 12 parallel first requests against a fresh database produce exactly 3 / 3 / 6
- deleting `Op 3` and editing `day_start_minute` to `480`, then restarting the worker against the same database (a redeploy), leaves both changes intact — the deleted operatory stays deleted and the edited setting is not reset